### PR TITLE
Fix public and federated timelines' scrolling

### DIFF
--- a/app/assets/stylesheets/containers.scss
+++ b/app/assets/stylesheets/containers.scss
@@ -13,7 +13,8 @@
   display: flex;
   height: 100%;
   width: 100%;
-
+  position: absolute;
+  
   // 707568 - height 100% doesn't work on child of a flex item - chromium - Monorail
   // https://bugs.chromium.org/p/chromium/issues/detail?id=707568
   flex: 1 1 auto;


### PR DESCRIPTION
According to the issue "public & federated timelines scroll the entire UI on safari 10.1 #2568" https://github.com/tootsuite/mastodon/issues/2568, a `position` line is added.